### PR TITLE
Added options array for make and refresh methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## [v2.4.0] - 2018-06-27
+
+### Added
+
+- Options array for `->user()->report()->make()` method
+- Options array for `->user()->report()->refresh()` method
+
 ## [v2.3.0] - 2018-06-27
 
 ### Added
@@ -33,6 +40,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - API backward compatible fix with passing empty data (for example - on calling `_refresh` method)
 
+[v2.4.0]:https://github.com/avto-dev/b2b-api-php/compare/v2.3.0...v2.4.0
 [v2.3.0]:https://github.com/avto-dev/b2b-api-php/compare/v2.2.0...v2.3.0
 [v2.2.0]:https://github.com/avto-dev/b2b-api-php/compare/v2.1.5...v2.2.0
 [v2.1.5]:https://github.com/avto-dev/b2b-api-php/compare/v2.1.4...v2.1.5

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 Для установки данного пакета выполните в терминале следующую команду:
 
 ```shell
-$ composer require avto-dev/b2b-api-php "^2.2"
+$ composer require avto-dev/b2b-api-php "^2.4"
 ```
 
 > Для этого необходим установленный `composer`. Для его установки перейдите по [данной ссылке][getcomposer].

--- a/src/Clients/v1/User/Report/ReportCommandsGroup.php
+++ b/src/Clients/v1/User/Report/ReportCommandsGroup.php
@@ -167,13 +167,14 @@ class ReportCommandsGroup extends AbstractApiCommandsGroup
      * @param string $query_id        Значение запрашиваемой сущности
      * @param string $report_type_uid UID типа отчета
      * @param bool   $is_force        Нужно ли перегенерировать отчет если он уже существует?
+     * @param array  $options         Дополнительные опции запроса
      *
      * @throws B2BApiInvalidArgumentException
      * @throws B2BApiException
      *
      * @return B2BResponse
      */
-    public function make($auth_token, $query_type, $query_id, $report_type_uid, $is_force = false)
+    public function make($auth_token, $query_type, $query_id, $report_type_uid, $is_force = false, array $options = [])
     {
         if (! QueryTypes::has($query_type)) {
             throw new B2BApiInvalidArgumentException(sprintf(
@@ -188,9 +189,9 @@ class ReportCommandsGroup extends AbstractApiCommandsGroup
             [
                 'queryType' => (string) $query_type,
                 'query'     => (string) $query_id,
-                'options'   => [
+                'options'   => \array_replace_recursive([
                     'FORCE' => (bool) $is_force,
-                ],
+                ], $options),
             ],
             [
                 'Authorization' => (string) $auth_token,
@@ -210,17 +211,22 @@ class ReportCommandsGroup extends AbstractApiCommandsGroup
      *
      * @param string $auth_token Токен безопасности
      * @param string $report_uid UID отчета
+     * @param array  $options    Дополнительные опции запроса
      *
      * @throws B2BApiException
      *
      * @return B2BResponse
      */
-    public function refresh($auth_token, $report_uid)
+    public function refresh($auth_token, $report_uid, array $options = [])
     {
+        $request_body = empty($options)
+            ? null
+            : ['options' => $options];
+
         return new B2BResponse($this->client->apiRequest(
             'post',
             sprintf('user/reports/%s/_refresh', urlencode($report_uid)),
-            null,
+            $request_body,
             [
                 'Authorization' => (string) $auth_token,
             ],

--- a/tests/Clients/v1/UserReportCommandsTest.php
+++ b/tests/Clients/v1/UserReportCommandsTest.php
@@ -112,7 +112,14 @@ class UserReportCommandsTest extends ClientTestCase
 
         $this->assertInstanceOf(
             B2BResponse::class,
-            $response = $this->client->user()->report()->make($this->dev_token, 'bla bla', 'A111AA177', $this->dev_test_report_type_uid)
+            $response = $this->client->user()->report()->make(
+                $this->dev_token,
+                'bla bla',
+                'A111AA177',
+                $this->dev_test_report_type_uid,
+                true,
+                []
+            )
         );
     }
 
@@ -123,7 +130,11 @@ class UserReportCommandsTest extends ClientTestCase
     {
         $this->assertInstanceOf(
             B2BResponse::class,
-            $response = $this->client->user()->report()->refresh($this->dev_token, $this->dev_test_report_uid)
+            $response = $this->client->user()->report()->refresh(
+                $this->dev_token,
+                $this->dev_test_report_uid,
+                []
+            )
         );
 
         foreach (['state', 'size', 'stamp', 'data'] as $key) {

--- a/tests/SomeFeatureTestsTest.php
+++ b/tests/SomeFeatureTestsTest.php
@@ -93,12 +93,7 @@ class SomeFeatureTestsTest extends AbstractUnitTestCase
      */
     protected function tearDown()
     {
-        unset($this->client);
-
-        unset($this->username);
-        unset($this->password);
-        unset($this->domain);
-        unset($this->report_type_uid);
+        unset($this->client, $this->username, $this->password, $this->domain, $this->report_type_uid);
 
         parent::tearDown();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

### Added

- Options array for `->user()->report()->make()` method
- Options array for `->user()->report()->refresh()` method

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/b2b-api-php/blob/master/CHANGELOG.md) file

> About your changes in `CHANGELOG.md`:
>
> * Add new version header like `## v2.x.x`, if it does not exists
> * Add description under `added`/`changed`/`fixed` sections
> * Add reference to closed issues `[#000]`
> * Add link to issue in the end of document
